### PR TITLE
update some deprecated methods

### DIFF
--- a/Step_1/mainpage.html
+++ b/Step_1/mainpage.html
@@ -29,7 +29,7 @@
         var viewer = new Autodesk.Viewing.Private.GuiViewer3D(viewerElement, {});
 
         Autodesk.Viewing.Initializer(options, function() {
-            viewer.initialize();
+            viewer.start();
             viewer.load(options.document);
         });
     }

--- a/Step_2/mainpage.html
+++ b/Step_2/mainpage.html
@@ -29,7 +29,7 @@
         var viewer = new Autodesk.Viewing.Private.GuiViewer3D(viewerElement, {});
 
         Autodesk.Viewing.Initializer(options, function() {
-            viewer.initialize();
+            viewer.start();
             viewer.load(options.document);
             viewer.addEventListener(
                 Autodesk.Viewing.GEOMETRY_LOADED_EVENT,

--- a/Step_3/mainpage.html
+++ b/Step_3/mainpage.html
@@ -29,7 +29,7 @@
         var viewer = new Autodesk.Viewing.Private.GuiViewer3D(viewerElement, {});
 
         Autodesk.Viewing.Initializer(options, function() {
-            viewer.initialize();
+            viewer.start();
             viewer.load(options.document);
             viewer.addEventListener(
                 Autodesk.Viewing.GEOMETRY_LOADED_EVENT,

--- a/Step_4/Viewing.Extension.Workshop.js
+++ b/Step_4/Viewing.Extension.Workshop.js
@@ -96,10 +96,10 @@
             propertiesHandler);
 
           _viewer.fitToView(dbId);
-          _viewer.isolateById(dbId);
+          _viewer.isolate(dbId);
         }
         else {
-          _viewer.isolateById([]);
+          _viewer.isolate([]);
           _viewer.fitToView();
           _self.panel.setVisible(false);
         }

--- a/Step_4/mainpage.html
+++ b/Step_4/mainpage.html
@@ -29,7 +29,7 @@
         var viewer = new Autodesk.Viewing.Private.GuiViewer3D(viewerElement, {});
 
         Autodesk.Viewing.Initializer(options, function() {
-            viewer.initialize();
+            viewer.start();
             viewer.load(options.document);
             viewer.addEventListener(
                 Autodesk.Viewing.GEOMETRY_LOADED_EVENT,

--- a/Step_5/Viewing.Extension.Workshop.js
+++ b/Step_5/Viewing.Extension.Workshop.js
@@ -100,14 +100,14 @@
         propertiesHandler);
 
       _viewer.fitToView(dbId);
-      _viewer.isolateById(dbId);
+      _viewer.isolate(dbId);
 
       _self.startRotation();
     }
     else {
-      clearInterval(_self.interval); // where is this function defined?
+      clearInterval(_self.interval); // where is this function defined? Go to line 151.
 
-      _viewer.isolateById([]);
+      _viewer.isolate([]);
       _viewer.fitToView();
       _self.panel.setVisible(false);
     }

--- a/Step_5/mainpage.html
+++ b/Step_5/mainpage.html
@@ -29,7 +29,7 @@
         var viewer = new Autodesk.Viewing.Private.GuiViewer3D(viewerElement, {});
 
         Autodesk.Viewing.Initializer(options, function() {
-            viewer.initialize();
+            viewer.start();
             viewer.load(options.document);
             viewer.addEventListener(
                 Autodesk.Viewing.GEOMETRY_LOADED_EVENT,

--- a/step-2.md
+++ b/step-2.md
@@ -91,7 +91,7 @@ In mainpage.html, locate the place where you load the model in your viewer code:
 
 ```js
        Autodesk.Viewing.Initializer(options, function() {
-            viewer.initialize();
+            viewer.start();
             viewer.load(options.document);
         });
 ```
@@ -100,7 +100,7 @@ Add the event handler to this function:
 
 ```js
         Autodesk.Viewing.Initializer(options, function() {
-            viewer.initialize();
+            viewer.start();
             viewer.load(options.document);
             
             viewer.addEventListener(
@@ -154,7 +154,7 @@ The entire, modified mainpage.html file now looks like this:
         var viewer = new Autodesk.Viewing.Private.GuiViewer3D(viewerElement, {});
 
         Autodesk.Viewing.Initializer(options, function() {
-            viewer.initialize();
+            viewer.start();
             viewer.load(options.document);
             viewer.addEventListener(
                 Autodesk.Viewing.GEOMETRY_LOADED_EVENT,

--- a/step-4.md
+++ b/step-4.md
@@ -123,10 +123,10 @@ Just for fun, we also isolate the component that is clicked:
         propertiesHandler);
 
       _viewer.fitToView(dbId);
-      _viewer.isolateById(dbId);
+      _viewer.isolate(dbId);
     }
     else {
-      _viewer.isolateById([]);
+      _viewer.isolate([]);
       _viewer.fitToView();
       _self.panel.setVisible(false);
     }


### PR DESCRIPTION
1. use viewer.start() instead of viewer.initialize().

viewer.start() is recommenced if viewer has some extensions in
construction so that the extensions can be loaded when view is
initialized:

var viewer = new Autodesk.Viewing.Private.GuiViewer3D(viewerElement,
{someExtension});
1. viewer.isolateById() is deprecated, use isolate() instead.
